### PR TITLE
Add Anti-Hate Group Policy

### DIFF
--- a/ANTI_HATE_GROUP_POLICY_EN.md
+++ b/ANTI_HATE_GROUP_POLICY_EN.md
@@ -1,0 +1,22 @@
+# Anti-Hate Group Policy
+
+## **Introduction**
+
+Our open source community is committed to fostering an inclusive, respectful, and safe environment for all participants. We believe in the power of diverse perspectives and the importance of creating a space where everyone feels welcome and valued.
+
+In line with these values, we have established this Anti-Hate Group Policy to ensure that our community remains free from hate, discrimination, and harassment. This policy applies to all community members, contributors, maintainers, and anyone else involved in our projects.
+
+## **Policy Statement**
+
+1. **No Affiliation with Hate Groups:** We strictly prohibit any affiliation with or promotion of hate groups, extremist ideologies, or any organization that promotes discrimination, violence, or harassment based on race, ethnicity, religion, gender, sexual orientation, disability, or any other protected characteristic.
+2. **No Hate Speech or Discriminatory Content:** Hate speech, slurs, stereotypes, or any content that demeans, degrades, or discriminates against individuals or groups based on their identity is not tolerated.
+3. **No Harassment or Intimidation:** Harassment, threats, intimidation, or any form of aggressive behavior towards others, whether based on their identity or not, is unacceptable.
+4. **Reporting and Enforcement:** We encourage community members to report any violations of this policy to the project maintainers or designated community leaders. All reports will be handled confidentially and promptly. Violations may result in warnings, temporary suspension, permanent banning, or other appropriate actions.
+5. **Responsibility to Uphold the Policy:** All community members are expected to understand and uphold this policy. Maintainers and community leaders have a special responsibility to enforce this policy and to lead by example.
+6. **Education and Awareness:** We are committed to providing resources, training, and support to educate community members about hate groups, discrimination, and how to foster an inclusive environment.
+
+## **Conclusion**
+
+Our open source community thrives on collaboration, creativity, and respect for one another. By adhering to this Anti-Hate Group Policy, we can ensure that our project remains a place where everyone can contribute and grow without fear of hate or discrimination.
+
+We invite all community members to join us in upholding these values and making our project a beacon of inclusivity and positive collaboration.

--- a/CODE_OF_CONDUCT_EN.md
+++ b/CODE_OF_CONDUCT_EN.md
@@ -33,6 +33,7 @@ Examples of unacceptable behavior include:
 * Public or private harassment
 * Publishing others' private information, such as a physical or email
   address, without their explicit permission
+* Our open source community strictly prohibits any affiliation with hate groups, hate speech, discrimination, harassment, and commits to fostering an inclusive, respectful, and safe environment for all participants. (_See [Anti-Hate Group Policy](./ANTI_HATE_GROUP_POLICY_EN.md)_)
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 


### PR DESCRIPTION
Due to some recent activity in the community, adding additional guidelines to more clearly define our policy with regards to hate groups. This policy gives greater detail than that covered by our general item, "Other conduct which could reasonably be considered inappropriate in a professional setting".